### PR TITLE
Fix for old base versions. Build was broken in commit da15938

### DIFF
--- a/vmeApp/devlib_compat.c
+++ b/vmeApp/devlib_compat.c
@@ -81,6 +81,7 @@ devLibVME *pdevLibVirtualOS = NULL;
 
 #endif /* NEED_PIMPL */
 
+#if EPICS_VERSION_INT>=VERSION_INT(3,14,10,0)
 #include <epicsExport.h>
 
 void devReplaceVirtualOS(void)
@@ -89,3 +90,4 @@ void devReplaceVirtualOS(void)
 }
 
 epicsExportRegistrar(devReplaceVirtualOS);
+#endif


### PR DESCRIPTION
Commit da15938 broke build for EPICS base versions < 3.14.10.
This fixes it.