### PR TITLE
Linux fix

### DIFF
--- a/exploreApp/src/devexplore.cpp
+++ b/exploreApp/src/devexplore.cpp
@@ -485,7 +485,7 @@ long explore_write_wf(waveformRecord *prec)
 {
     TRY {
         Guard G(pvt->lock);
-        unsigned nwritten = -1;
+        unsigned nwritten = 0;
         switch(prec->ftvl) {
         case menuFtypeCHAR  :
         case menuFtypeUCHAR : nwritten = pvt->writeArray((epicsUInt8*)  prec->bptr, prec->nord); break;

--- a/exploreApp/src/devexplore.cpp
+++ b/exploreApp/src/devexplore.cpp
@@ -138,7 +138,7 @@ struct priv {
     template<typename VAL>
     VAL read(epicsUInt32 off=0) const
     {
-        epicsUInt32 OV(readraw<VAL>(off));
+        epicsUInt32 OV(readraw<epicsUInt32>(off));
         if(vmask) OV &= vmask;
         OV >>= vshift;
         return OV;
@@ -152,7 +152,7 @@ struct priv {
         unsigned i;
         for(i=0; i<count && addr<end; i++, addr+=step)
         {
-            epicsUInt32 OV = read<VAL>(addr);
+            epicsUInt32 OV = read<epicsUInt32>(addr);
             *val++ = castval<VAL,epicsUInt32>::op(OV);
         }
         return i;

--- a/pciApp/os/Linux/devLibPCIOSD.c
+++ b/pciApp/os/Linux/devLibPCIOSD.c
@@ -772,7 +772,7 @@ done:
 static const char* fd2filename(int fd, char* buffer, size_t buffersize)
 {
     char procfile[32];
-    size_t n;
+    ssize_t n;
 
     sprintf(procfile, "/proc/self/fd/%d", fd);
     n = readlink(procfile, buffer, buffersize-1);


### PR DESCRIPTION
In explore_write_wf()  `unsigned nwritten = -1;` causes a warning and is not necessary. Initializing to 0 is sufficient. Either nwritten will be updated or when left untouched the alarm will be set anyway.

The other fix is related to #8 